### PR TITLE
Fixed Bug: Corrected nil table reference in YGNode:clearChildren()

### DIFF
--- a/packages/yoga-sys/src/ygnode.luau
+++ b/packages/yoga-sys/src/ygnode.luau
@@ -768,7 +768,7 @@ end
 
 function YGNode:clearChildren(): ()
     while #self.children_ > 0 do
-        table.remove(self.children)
+        table.remove(self.children_)
     end
 end
 


### PR DESCRIPTION
Calling free() would error due to a nil table reference in YGNode:clearChildren(). This fix addresses the issue by changing the nil table reference to self.children_.